### PR TITLE
Add support for Zenoss Cloud

### DIFF
--- a/src/zenossapi/routers/__init__.py
+++ b/src/zenossapi/routers/__init__.py
@@ -48,7 +48,7 @@ class ZenossRouter(object):
             )
         except ConnectionError as e:
             raise ZenossAPIClientError(
-                'Unable to connect to Zenoss server {0}'.format(self.api_url)
+                'Unable to connect to Zenoss server {0}: {1}'.format(self.api_url, e)
             )
 
         if response.ok:

--- a/src/zenossapi/routers/events.py
+++ b/src/zenossapi/routers/events.py
@@ -46,8 +46,8 @@ class EventsRouter(ZenossRouter):
         )
 
     def _query_events(self, limit=10, start=0, sort='lastTime', sort_dir='DESC',
-                      params=None, exclude=None, keys=None,
-                      context=None, archive=False):
+                      params=None, exclude=None, keys=None, context=None,
+                      archive=False, validate_params=True, detail_format=False):
         """
         Get a list of events based on query parameters.
 
@@ -73,6 +73,8 @@ class EventsRouter(ZenossRouter):
             keys (list): List of keys to include in the return event data
             context (str): Device or device class uid as context for the query
             archive (bool): Search the events archive instead of active events
+            validate_params (bool): Check input params against known param list
+            detail_format (bool): Request detail format of return parameters
 
         Returns:
             dict(int, float, list(dict)): ::
@@ -113,7 +115,7 @@ class EventsRouter(ZenossRouter):
                         'summary',
                         'systems'}
 
-        if params:
+        if params and validate_params:
             param_keys = set(params.keys())
             bad_params = param_keys.difference(valid_params)
             for bad in bad_params:
@@ -127,6 +129,7 @@ class EventsRouter(ZenossRouter):
                     start=start,
                     sort=sort,
                     dir=sort_dir,
+                    detailFormat=detail_format,
                     params=params,
                     exclusion_filter=exclude,
                     keys=keys,
@@ -164,7 +167,7 @@ class EventsRouter(ZenossRouter):
         return event_data['event'][0]
 
     def _event_actions(self, action, evids=None, exclude_ids=None, params=None,
-                      context=None, last_change=None, limit=None, timeout=60):
+                       context=None, last_change=None, limit=None, timeout=60):
         """
         Close events by either passing a list of event ids or by a query.
 

--- a/src/zenossapi/routers/incidentmanagement.py
+++ b/src/zenossapi/routers/incidentmanagement.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+
+"""
+Zenoss Events/IncidentManagementRouter
+"""
+
+from zenossapi.routers import ZenossRouter
+
+
+class IncidentManagementRouter(ZenossRouter):
+    """
+    Class for interacting with the Zenoss incidentmanagement router
+    """
+
+    def __init__(self, url, headers, ssl_verify):
+        super(IncidentManagementRouter, self).__init__(url, headers, ssl_verify,
+                                                       'Events/IncidentManagementRouter',
+                                                       'IncidentManagementRouter')
+
+    def __repr__(self):
+        identifier = "at {0}".format(hex(id(self)))
+
+        return '<{0} object {1}>'.format(
+            type(self).__name__, identifier
+        )
+
+    def associate_incident_to_event(self, notification, incident, evids):
+        """
+        Associates an incident with a specific event ID.
+
+        Arguments:
+            notification (str): URI path to NotificationSubscriptions
+            incident (str): The incident ID
+            evids (list): The event IDs
+        """
+        self._router_request(
+            self._make_request_data(
+                'associateIncident',
+                dict(
+                    notification=notification,
+                    number=incident,
+                    evids=evids
+                )
+            )
+        )

--- a/src/zenossapi/routers/incidentmanagement.py
+++ b/src/zenossapi/routers/incidentmanagement.py
@@ -6,6 +6,8 @@ Zenoss Events/IncidentManagementRouter
 
 from zenossapi.routers import ZenossRouter
 
+__router__ = 'IncidentManagementRouter'
+
 
 class IncidentManagementRouter(ZenossRouter):
     """

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -2,7 +2,7 @@ import pytest
 from zenossapi import apiclient as zapi
 from zenossapi.routers.events import EventsRouter
 
-host = 'zenoss'
+host = 'https://zenoss'
 user = 'admin'
 password = 'zenoss'
 collection_zone = 'cz1'
@@ -13,12 +13,12 @@ class TestZenossClient(object):
 
     def test_client_init(self):
         zc = zapi.Client(host=host, user=user, password=password)
-        assert zc.api_url == 'https://{0}/zport/dmd'.format(host)
+        assert zc.api_url == '{0}/zport/dmd'.format(host)
         assert 'authorization' in zc.api_headers
         assert zc.ssl_verify
 
         zc = zapi.Client(host=host, collection_zone=collection_zone, api_key=api_key)
-        assert zc.api_url == 'https://{0}/{1}/zport/dmd'.format(host, collection_zone)
+        assert zc.api_url == '{0}/{1}/zport/dmd'.format(host, collection_zone)
         assert 'z-api-key' in zc.api_headers
         assert zc.ssl_verify
 

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -5,15 +5,21 @@ from zenossapi.routers.events import EventsRouter
 host = 'zenoss'
 user = 'admin'
 password = 'zenoss'
+collection_zone = 'cz1'
+api_key = 'a594730e-293c-4d32-915e-edf43aa9bae8'
 
 
 class TestZenossClient(object):
 
     def test_client_init(self):
         zc = zapi.Client(host=host, user=user, password=password)
-        assert zc.api_host == host
         assert zc.api_url == 'https://{0}/zport/dmd'.format(host)
-        assert zc.api_user == user
+        assert 'authorization' in zc.api_headers
+        assert zc.ssl_verify
+
+        zc = zapi.Client(host=host, collection_zone=collection_zone, api_key=api_key)
+        assert zc.api_url == 'https://{0}/{1}/zport/dmd'.format(host, collection_zone)
+        assert 'z-api-key' in zc.api_headers
         assert zc.ssl_verify
 
     def test_client_get_routers(self):


### PR DESCRIPTION
Zenoss Cloud has a slightly different URL/auth mechanism than the traditional on premise solution. This PR adds support for this, adds support for an additional router, as well as makes the existing events router query method more generic.